### PR TITLE
Websocket optional send synchronization

### DIFF
--- a/socket-io/src/main/java/com/codeminders/socketio/server/Config.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/Config.java
@@ -36,11 +36,15 @@ public interface Config
     String BUFFER_SIZE = "bufferSize";
     String MAX_IDLE    = "maxIdleTime";
 
+    String WEBSOCKET_SEND_SYNCHRONIZED = "websocketSendSynchronized";
+
     int DEFAULT_BUFFER_SIZE = 8192;
     int DEFAULT_MAX_IDLE    = 300 * 1000;
 
     int DEFAULT_PING_INTERVAL = 25 * 1000; // 25s
     int DEFAULT_PING_TIMEOUT  = 60 * 1000; // 60s
+
+    boolean DEFAULT_WEBSOCKET_SEND_SYNCHRONIZED = false;
 
     long getPingInterval(long def);
 
@@ -61,4 +65,6 @@ public interface Config
     boolean getBoolean(String key, boolean def);
 
     String getNamespace();
+
+    boolean isWebsocketSendSynchronized();
 }

--- a/socket-io/src/main/java/com/codeminders/socketio/server/ServletBasedConfig.java
+++ b/socket-io/src/main/java/com/codeminders/socketio/server/ServletBasedConfig.java
@@ -109,4 +109,9 @@ public final class ServletBasedConfig implements Config
         return v == null ? def : v;
     }
 
+    @Override
+    public boolean isWebsocketSendSynchronized()
+    {
+        return getBoolean(Config.WEBSOCKET_SEND_SYNCHRONIZED, Config.DEFAULT_WEBSOCKET_SEND_SYNCHRONIZED);
+    }
 }


### PR DESCRIPTION
Depending on this parameter websocket transport "send" methods are either wrapped synchronized block or not.
Change was made due to invalid socket state exception (FULL_TEXT_WRITING) on simultaneously emitted messages via same websocket instance.